### PR TITLE
Not trusting the forwarded host if our configuration is incorrect

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,11 @@ module.exports = function(config) {
     }
 
     const trusted = req.ips.some(ip => trustedIps.has(ip));
-
     if (!trusted && dnsEntry) {
       //if is not trusted yet
       //fetch the ip addresses and check
       return dns.resolve(dnsEntry, (err, ips) => {
-        if (err) { return next(); }
-        trustedIps = new Set(ips);
+        trustedIps = new Set(err && [] || ips);
         const trusted = req.ips.some(ip => trustedIps.has(ip));
         validateAndNext(trusted, req, next);
       });

--- a/test/tests.js
+++ b/test/tests.js
@@ -127,7 +127,6 @@ describe('trustforwardedhost', function () {
       });
     });
 
-
     it('should not remove the header if it is trusted', function(done) {
       const request = mockrequest(['19.20.21.22', ip],
                                   'main.example.com',
@@ -140,7 +139,17 @@ describe('trustforwardedhost', function () {
       });
     });
 
+    it('should ignore the header if the LB dns entry is incorrect', function(done) {
+      const tfhUnknownDomain = trustforwardedhost('fafeazfezmffijamfomezaf.com');
+      const request = mockrequest(['19.20.21.22'],
+                                  'main.example.com',
+                                  'fake.example.com');
+
+      tfhUnknownDomain(request, null, () => {
+        assert.notProperty(request, 'x-forwarded-host');
+        assert.equal(request.host, 'main.example.com');
+        done();
+      });
+    });
   });
-
-
 });


### PR DESCRIPTION
When I try to configure the DNS entry of an LB but make a mistake, the x-forwarded-host will simply be trusted (in case the DNS entry of my LB is not correct).

This PR fixes it.